### PR TITLE
typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ export default function shoppingListItemReducer(
 ) {
   switch (action.type) {
     case 'INCREASE_COUNT':
-      return return {
+      return {
         ...state,
         items: state.items.concat(state.items.length + 1)
       }


### PR DESCRIPTION
Removed a 'return return'. Only one return is needed.